### PR TITLE
Simplify api/app paths (for future deployment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/amarcic/PreisausschreibenApp#readme",
   "config": {
-    "couchdb": "https://musical-competitions.uni-koeln.de/api/",
+    "couchdb": "/preisausschreiben/",
     "couchdb_version": "1.6.1",
-    "elasticsearch": "https://musical-competitions.uni-koeln.de/search",
+    "elasticsearch": "/",
     "elasticsearch_version": "1.7.6",
-    "react_router_basename": "/app"
+    "react_router_basename": "/"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
This Pull Request replaces all absolute URL with their relative counterparts, and drops the superfluous `/app/` context path from the React Router. I've tested as far as possible, this seems to work so far.