### PR TITLE
Fix relative ElasticSearch endpoint path

### DIFF
--- a/src/withESData.jsx
+++ b/src/withESData.jsx
@@ -11,7 +11,7 @@ import * as packageJSON from '../package.json';
 console.log("couchdb: " +packageJSON.default.config.basename);
 
 let client = new elasticsearch.Client({
-    host: packageJSON.default.config.elasticsearch,
+    host: new URL(packageJSON.default.config.elasticsearch, location).href,
     //host: 'search.musical-competitions.uni-koeln.de:80',
     log: 'trace'
 });

--- a/src/withESDataMap.jsx
+++ b/src/withESDataMap.jsx
@@ -11,7 +11,7 @@ import * as packageJSON from '../package.json';
 console.log("couchdb: " +packageJSON.default.config.basename);
 
 let client = new elasticsearch.Client({
-    host: packageJSON.default.config.elasticsearch,
+    host: new URL(packageJSON.default.config.elasticsearch, location).href,
     //host: 'search.musical-competitions.uni-koeln.de:80',
     log: 'trace'
 });


### PR DESCRIPTION
This Pull Request fixes the usage of relative paths to construct ElasticSearch client endpoint by piping the configured endpoint through the `URL` constructor, while supplying the current `location` as `base`. Relative endpoint paths are thereby converted into absolute URLs while already absolute URLs remain unchanged.